### PR TITLE
docs: show both uv and pip install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Downloaded models land under `<assets_dir>/cache/sketchfab/` and are immediately
 
 ## Install
 
+Match the install method you used for BowerBot itself.
+
+If you installed BowerBot with `uv tool install`, add the skill to the same tool environment:
+
+```bash
+uv tool install bowerbot --with bowerbot-skill-sketchfab --reinstall
+```
+
+If you installed BowerBot with `pip` (in a venv or system-wide), install the skill into the same Python environment:
+
 ```bash
 pip install bowerbot-skill-sketchfab
 ```


### PR DESCRIPTION
## Summary

- Adds the `uv tool install bowerbot --with bowerbot-skill-sketchfab --reinstall` path for users who installed BowerBot via uv
- Keeps the existing `pip install bowerbot-skill-sketchfab` path for users on pip
- Mirrors the two-end-user-paths convention adopted in bowerbot 1.5.0+

This is also the first PR after the new org-level ruleset went live, so it doubles as the verification that `check-branch-name` runs and gets registered as a known GitHub Actions source on this repo.
