### PR TITLE
chore: add dependabot config and bypass branch-check for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  # Python dependencies (managed by uv)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-runtime:
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-dev:
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  # GitHub Actions versions in workflow files
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -15,7 +15,13 @@ jobs:
 
           # Allow release-please automated branches
           if [[ "$BRANCH" =~ ^release-please-- ]]; then
-            echo "Release Please branch '$BRANCH' — skipping name check"
+            echo "Release Please branch '$BRANCH', skipping name check"
+            exit 0
+          fi
+
+          # Allow Dependabot automated branches
+          if [[ "$BRANCH" =~ ^dependabot/ ]]; then
+            echo "Dependabot branch '$BRANCH', skipping name check"
             exit 0
           fi
 


### PR DESCRIPTION
- Add .github/dependabot.yml mirroring the bowerbot core: weekly grouped updates for Python (uv) and GitHub Actions ecosystems
- Group minor/patch updates per dependency-type to reduce PR noise; major bumps get individual PRs for review
- Use 'chore' commit prefix with scope so Dependabot PRs flow through release-please without triggering version bumps
- Update branch-check.yml to bypass dependabot/ branches the same way release-please-- branches are bypassed
- Drop the em-dash in the existing release-please bypass message