### PR TITLE
chore: declare minimum workflow permissions

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check-branch-name:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set explicit 'permissions:' blocks on all three workflows following GitHub's defense-in-depth recommendation, mirroring the bowerbot core change:

- branch-check.yml: workflow-level 'permissions: {}'. Reads PR event metadata only, no repo access needed.
- ci.yml: workflow-level 'permissions: contents: read'. Required for actions/checkout; lint and tests need nothing else.
- release-please.yml: workflow-level 'permissions: {}' as the default; per-job grants stay as they were ('contents: write' + 'pull-requests: write' for release-please, 'contents: write' for sync-lockfile, 'id-token: write' + 'contents: read' for publish-pypi).

With workflow-level defaults set to the minimum, any new job added later inherits zero permissions until it explicitly declares what it needs. Closes the two CodeQL 'workflow does not contain permissions' alerts on this repo.