### PR TITLE
chore: tell dependabot to skip major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Major version bumps are project decisions, not bot decisions.
+      # Read the changelog, plan a migration PR, run integration tests.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
 
@@ -53,6 +58,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Major version bumps for actions can carry breaking changes too
+      # (input renames, runtime changes). Treat them as deliberate.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
Mirrors the bowerbot core change. Adds 'ignore' rules to both ecosystems so Dependabot stops opening major-version PRs without explicit human review:

- Python (uv): bumps like rich 14 -> 15 or pydantic 2 -> 3 carry breaking API risk. Major upgrades are project decisions; we will open them deliberately as a migration PR after reading the changelog and running integration tests.
- GitHub Actions: bumps like actions/checkout 4 -> 6 or setup-uv 4 -> 7 can change inputs or the underlying runtime. Same reasoning.

Patch and minor bumps continue to flow through Dependabot in grouped weekly PRs. Security PRs (Dependabot alerts -> auto-fix) are unaffected by this rule and still open as before.