### PR TITLE
chore: harden renovate.json after first-pass review

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,43 +6,51 @@
     ":semanticCommitScope(deps)",
     ":dependencyDashboard"
   ],
-  "schedule": ["before 6am on monday"],
-  "timezone": "Etc/UTC",
+  "configMigration": true,
+  "schedule": ["* 0-5 * * 1"],
+  "timezone": "UTC",
   "branchPrefix": "chore/renovate-",
   "minimumReleaseAge": "5 days",
+  "internalChecksFilter": "strict",
   "rangeStrategy": "update-lockfile",
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "prCreation": "not-pending",
+  "osvVulnerabilityAlerts": true,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am on monday"]
+    "schedule": ["* 0-5 * * 1"]
   },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "labels": ["security"],
-    "minimumReleaseAge": "0 days",
-    "schedule": ["at any time"]
+    "addLabels": ["security"],
+    "minimumReleaseAge": "0 days"
   },
   "packageRules": [
     {
-      "matchManagers": ["pep621"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "python minor and patch",
-      "commitMessagePrefix": "chore(deps):"
-    },
-    {
-      "matchManagers": ["pep621"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": ["pyenv"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies", "project.optional-dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "github actions",
-      "commitMessagePrefix": "chore(deps):"
+      "groupName": "python-runtime"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["dependency-groups", "tool.uv.dev-dependencies", "build-system.requires"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python-dev"
     },
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "github-actions"
     }
   ]
 }


### PR DESCRIPTION
Mirrors the bowerbot core change. Six gaps fixed plus production-grade additions verified against official Renovate docs (May 2026).

Fixes:
- vulnerabilityAlerts.labels -> addLabels
- Drop redundant commitMessagePrefix (semantic commit presets handle it; the explicit prefix overrode their lowercasing)
- schedule text syntax deprecated; switched to cron '* 0-5 * * 1'
- Disable pyenv manager (Python 3.x.y bumps look like minor in semver, so global major-block does not catch them); we will bump Python manually when ready
- internalChecksFilter 'strict' so cooldown skips branch creation
- prCreation 'not-pending' so PRs only appear once CI starts

Additions:
- configMigration: true for auto-migration of config schema
- prHourlyLimit 5 + prConcurrentLimit 10 for sane throttling
- osvVulnerabilityAlerts: true for broader CVE coverage
- pep621 split by matchDepTypes into python-runtime and python-dev groups, matching Dependabot's prior dependency-type split

Single global 'matchUpdateTypes major -> enabled false' replaces the per-manager major blocks; catches every manager.