### PR TITLE
fix(renovate): open PRs immediately to avoid CI deadlock

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "rangeStrategy": "update-lockfile",
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "osvVulnerabilityAlerts": true,
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
CI only runs on pull_request, so feature-branch pushes never get a status. With prCreation=not-pending, Renovate waits forever for a non-pending status before opening the PR, so branches are created but no PR ever opens. Switching to immediate matches the main bowerbot repo fix (#147).