### PR TITLE
fix: handle Sketchfab WAF blocks and empty/non-JSON responses

### DIFF
--- a/src/bowerbot_skill_sketchfab/services/search_service.py
+++ b/src/bowerbot_skill_sketchfab/services/search_service.py
@@ -14,6 +14,7 @@ from bowerbot_skill_sketchfab.utils.api_utils import (
     BASE_URL,
     auth_headers,
     format_model_list,
+    parse_response,
 )
 
 
@@ -21,28 +22,34 @@ async def search_my_models(token: str, params: dict[str, Any]) -> ToolResult:
     """Search the authenticated user's own Sketchfab library."""
     query = params["query"]
     max_results = min(params.get("max_results", 10), 24)
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            f"{BASE_URL}/me/models",
-            params={"q": query, "count": max_results},
-            headers=auth_headers(token),
-            timeout=15.0,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{BASE_URL}/me/models",
+                params={"q": query, "count": max_results},
+                headers=auth_headers(token),
+                timeout=15.0,
+            )
+            resp.raise_for_status()
+            data = parse_response(resp, "/me/models")
+    except (httpx.HTTPError, RuntimeError) as e:
+        return ToolResult(success=False, error=str(e))
     return ToolResult(success=True, data=format_model_list(data))
 
 
 async def list_my_models(token: str, params: dict[str, Any]) -> ToolResult:
     """List every model in the authenticated user's account."""
     max_results = min(params.get("max_results", 24), 24)
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(
-            f"{BASE_URL}/me/models",
-            params={"count": max_results},
-            headers=auth_headers(token),
-            timeout=15.0,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{BASE_URL}/me/models",
+                params={"count": max_results},
+                headers=auth_headers(token),
+                timeout=15.0,
+            )
+            resp.raise_for_status()
+            data = parse_response(resp, "/me/models")
+    except (httpx.HTTPError, RuntimeError) as e:
+        return ToolResult(success=False, error=str(e))
     return ToolResult(success=True, data=format_model_list(data))

--- a/src/bowerbot_skill_sketchfab/utils/api_utils.py
+++ b/src/bowerbot_skill_sketchfab/utils/api_utils.py
@@ -7,12 +7,42 @@ from __future__ import annotations
 
 from typing import Any
 
+import httpx
+
 BASE_URL = "https://api.sketchfab.com/v3"
 
 
 def auth_headers(token: str) -> dict[str, str]:
-    """Build the Authorization header for Sketchfab API calls."""
-    return {"Authorization": f"Token {token}"}
+    """Build the Authorization + User-Agent headers for Sketchfab API calls."""
+    return {
+        "Authorization": f"Token {token}",
+        "User-Agent": "bowerbot-skill-sketchfab/1.0",
+    }
+
+
+def parse_response(resp: httpx.Response, endpoint: str) -> dict[str, Any]:
+    """Parse a Sketchfab response, raising a clear error on WAF / empty body."""
+    waf_action = resp.headers.get("x-amzn-waf-action")
+    if waf_action:
+        raise RuntimeError(
+            f"Sketchfab WAF blocked the request to {endpoint} "
+            f"(action={waf_action!r}). This is IP-based rate limiting from "
+            "AWS CloudFront, not an auth or skill problem. Wait a few "
+            "minutes and retry, or switch networks."
+        )
+    if not resp.content:
+        raise RuntimeError(
+            f"Sketchfab returned an empty body (HTTP {resp.status_code}) "
+            f"for {endpoint}. Likely rate limit, outage, or temporary "
+            "server-side error. Retry in a moment.",
+        )
+    try:
+        return resp.json()
+    except ValueError as e:
+        raise RuntimeError(
+            f"Sketchfab returned non-JSON (HTTP {resp.status_code}) "
+            f"for {endpoint}: {resp.content[:200]!r}",
+        ) from e
 
 
 def safe_file_name(name: str) -> str:


### PR DESCRIPTION
Add parse_response() to surface clear errors for AWS WAF rate limiting, empty bodies, and non-JSON payloads instead of opaque JSON decode errors. Wrap the my-models search/list calls in try/except so failures return a ToolResult error, and send a User-Agent header on all API requests.