### PR TITLE
fix: use requests instead of httpx to dodge CloudFront WAF block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # a follow-up release. End users are protected from accidentally
     # picking up breaking changes via `pip install bowerbot-skill-sketchfab`.
     "bowerbot>=1.5,<2",
-    "httpx>=0.27,<1",
+    "requests>=2.32,<3",
     "pydantic>=2.0,<3",
 ]
 

--- a/src/bowerbot_skill_sketchfab/services/download_service.py
+++ b/src/bowerbot_skill_sketchfab/services/download_service.py
@@ -5,15 +5,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
-import httpx
 from bowerbot.skills import SkillContext, ToolResult
 
 from bowerbot_skill_sketchfab.utils.api_utils import (
-    BASE_URL,
-    auth_headers,
+    get_bytes,
+    get_json,
     safe_file_name,
 )
 
@@ -34,33 +34,26 @@ async def download_model(
     name = params["name"]
     safe_name = safe_file_name(name) or uid
 
-    async with httpx.AsyncClient(follow_redirects=True) as client:
-        resp = await client.get(
-            f"{BASE_URL}/models/{uid}/download",
-            headers=auth_headers(token),
-            timeout=15.0,
+    download_info = await asyncio.to_thread(
+        get_json, f"/models/{uid}/download", token,
+    )
+
+    usdz = download_info.get("usdz") or {}
+    if not usdz.get("url"):
+        return ToolResult(
+            success=False,
+            error=(
+                f"Model '{name}' ({uid}) has no USDZ format available. "
+                "Only USD assets are supported."
+            ),
         )
-        resp.raise_for_status()
-        download_info = resp.json()
 
-        usdz = download_info.get("usdz") or {}
-        if not usdz.get("url"):
-            return ToolResult(
-                success=False,
-                error=(
-                    f"Model '{name}' ({uid}) has no USDZ format available. "
-                    "Only USD assets are supported."
-                ),
-            )
+    download_url = usdz["url"]
+    file_size = usdz.get("size", 0)
+    logger.info("Downloading USDZ (%s bytes) for %s", file_size, name)
 
-        download_url = usdz["url"]
-        file_size = usdz.get("size", 0)
-        logger.info("Downloading USDZ (%s bytes) for %s", file_size, name)
-
-        final_path = ctx.cache_dir / f"{safe_name}.usdz"
-        resp = await client.get(download_url, timeout=120.0)
-        resp.raise_for_status()
-        final_path.write_bytes(resp.content)
+    final_path = ctx.cache_dir / f"{safe_name}.usdz"
+    final_path.write_bytes(await asyncio.to_thread(get_bytes, download_url))
 
     logger.info("Downloaded %s to %s", name, final_path)
     return ToolResult(

--- a/src/bowerbot_skill_sketchfab/services/search_service.py
+++ b/src/bowerbot_skill_sketchfab/services/search_service.py
@@ -5,16 +5,15 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
-import httpx
+import requests
 from bowerbot.skills import ToolResult
 
 from bowerbot_skill_sketchfab.utils.api_utils import (
-    BASE_URL,
-    auth_headers,
     format_model_list,
-    parse_response,
+    get_json,
 )
 
 
@@ -23,16 +22,10 @@ async def search_my_models(token: str, params: dict[str, Any]) -> ToolResult:
     query = params["query"]
     max_results = min(params.get("max_results", 10), 24)
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{BASE_URL}/me/models",
-                params={"q": query, "count": max_results},
-                headers=auth_headers(token),
-                timeout=15.0,
-            )
-            resp.raise_for_status()
-            data = parse_response(resp, "/me/models")
-    except (httpx.HTTPError, RuntimeError) as e:
+        data = await asyncio.to_thread(
+            get_json, "/me/models", token, {"q": query, "count": max_results},
+        )
+    except (requests.RequestException, RuntimeError) as e:
         return ToolResult(success=False, error=str(e))
     return ToolResult(success=True, data=format_model_list(data))
 
@@ -41,15 +34,9 @@ async def list_my_models(token: str, params: dict[str, Any]) -> ToolResult:
     """List every model in the authenticated user's account."""
     max_results = min(params.get("max_results", 24), 24)
     try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{BASE_URL}/me/models",
-                params={"count": max_results},
-                headers=auth_headers(token),
-                timeout=15.0,
-            )
-            resp.raise_for_status()
-            data = parse_response(resp, "/me/models")
-    except (httpx.HTTPError, RuntimeError) as e:
+        data = await asyncio.to_thread(
+            get_json, "/me/models", token, {"count": max_results},
+        )
+    except (requests.RequestException, RuntimeError) as e:
         return ToolResult(success=False, error=str(e))
     return ToolResult(success=True, data=format_model_list(data))

--- a/src/bowerbot_skill_sketchfab/utils/api_utils.py
+++ b/src/bowerbot_skill_sketchfab/utils/api_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import httpx
+import requests
 
 BASE_URL = "https://api.sketchfab.com/v3"
 
@@ -20,15 +20,14 @@ def auth_headers(token: str) -> dict[str, str]:
     }
 
 
-def parse_response(resp: httpx.Response, endpoint: str) -> dict[str, Any]:
+def parse_response(resp: requests.Response, endpoint: str) -> dict[str, Any]:
     """Parse a Sketchfab response, raising a clear error on WAF / empty body."""
     waf_action = resp.headers.get("x-amzn-waf-action")
     if waf_action:
         raise RuntimeError(
-            f"Sketchfab WAF blocked the request to {endpoint} "
-            f"(action={waf_action!r}). This is IP-based rate limiting from "
-            "AWS CloudFront, not an auth or skill problem. Wait a few "
-            "minutes and retry, or switch networks."
+            f"Sketchfab's AWS CloudFront WAF challenged the request to "
+            f"{endpoint} (action={waf_action!r}). Retry shortly or switch "
+            "networks; this is not an auth or skill problem."
         )
     if not resp.content:
         raise RuntimeError(
@@ -43,6 +42,30 @@ def parse_response(resp: httpx.Response, endpoint: str) -> dict[str, Any]:
             f"Sketchfab returned non-JSON (HTTP {resp.status_code}) "
             f"for {endpoint}: {resp.content[:200]!r}",
         ) from e
+
+
+def get_json(
+    endpoint: str,
+    token: str,
+    params: dict[str, Any] | None = None,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    """Blocking authenticated GET of a BASE_URL-relative endpoint, parsed as JSON."""
+    resp = requests.get(
+        f"{BASE_URL}{endpoint}",
+        params=params,
+        headers=auth_headers(token),
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    return parse_response(resp, endpoint)
+
+
+def get_bytes(url: str, timeout: float = 120.0) -> bytes:
+    """Blocking GET of a pre-signed download URL, returning the raw body."""
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.content
 
 
 def safe_file_name(name: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -173,8 +173,8 @@ version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "bowerbot" },
-    { name = "httpx" },
     { name = "pydantic" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -187,10 +187,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bowerbot", specifier = ">=1.5,<2" },
-    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "pydantic", specifier = ">=2.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<10" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23,<2" },
+    { name = "requests", specifier = ">=2.32,<3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4,<1" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Sketchfab's AWS CloudFront WAF fingerprints httpx's TLS handshake and challenges every request (HTTP 202, x-amzn-waf-action: challenge, empty body), while curl/requests/urllib3 are served normally from the same IP in the same second. It's a client-fingerprint block, not rate limiting, so retrying never clears it.

Swap the transport to requests. The Skill contract requires an async execute(), so the blocking calls are offloaded via asyncio.to_thread to keep the event loop unblocked. Request primitives move into api_utils (get_json/get_bytes) and services orchestrate them. Also corrects the WAF error message to drop the inaccurate IP-rate-limit claim.